### PR TITLE
Changes for liveness and readiness probe

### DIFF
--- a/k8s/base/deployment.yaml
+++ b/k8s/base/deployment.yaml
@@ -15,14 +15,14 @@ spec:
             httpGet:
               port: 8081
               path: /actuator/info
-            initialDelaySeconds: 100
-            periodSeconds: 60
+            initialDelaySeconds: 55
+            periodSeconds: 20
           readinessProbe:
             httpGet:
               port: 8081
               path: /actuator/info
-            initialDelaySeconds: 30
-            periodSeconds: 30
+            initialDelaySeconds: 55
+            periodSeconds: 20
           env:
             - name: SPRING_CONFIG_ADDITIONAL_LOCATION
               value: "file:/opt/app/config/sitemap.user.properties"

--- a/k8s/base/deployment.yaml
+++ b/k8s/base/deployment.yaml
@@ -14,13 +14,13 @@ spec:
           livenessProbe:
             httpGet:
               port: 8081
-              path: /actuator/info
+              path: /actuator/health/liveness
             initialDelaySeconds: 55
             periodSeconds: 20
           readinessProbe:
             httpGet:
               port: 8081
-              path: /actuator/info
+              path: /actuator/health/readiness
             initialDelaySeconds: 55
             periodSeconds: 20
           env:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,8 +14,20 @@ management:
   endpoints:
     web:
       exposure:
-        include: info
+        include: info, health
 
   info:
     env:
+      enabled: true
+
+  endpoint:
+    health:
+      probes:
+        enabled: true
+      show-details: always
+
+  health:
+    livenessState:
+      enabled: true
+    readinessState:
       enabled: true


### PR DESCRIPTION
New values are based on analysis of max-min application startup time from prod /acceptance/test environment
observed (max-min) 47.361- 38.839 seconds for sitemap api